### PR TITLE
usb-export: always unbind from current driver

### DIFF
--- a/src/usb-export
+++ b/src/usb-export
@@ -85,17 +85,14 @@ modprobe usbip-host || exit 1
 kill -USR1 "$QREXEC_AGENT_PID" || exit 1
 
 busid=$(basename "$devpath")
-# Unbind the device from other drivers
-if [ -d "$devpath/driver" -a \
-        "$(readlink -f $devpath/driver)" != "$SYS_USBIP_HOST" ]; then
+# Unbind the device from the driver
+if [ -d "$devpath/driver" ]; then
     echo $busid > $devpath/driver/unbind || exit 1
 fi
 
-# Bind to the usbip-host driver if needed
-if ! [ -e $SYS_USBIP_HOST/$busid ]; then
-    echo -n add $busid > $SYS_USBIP_HOST/match_busid || exit 1
-    echo $busid > $SYS_USBIP_HOST/bind || exit 1
-fi
+# Bind to the usbip-host driver
+echo -n add $busid > $SYS_USBIP_HOST/match_busid || exit 1
+echo $busid > $SYS_USBIP_HOST/bind || exit 1
 
 # One more safety check - make sure the device is available
 if [ "$(cat $devpath/usbip_status)" -ne $SDEV_ST_AVAILABLE ]; then


### PR DESCRIPTION
Previously, usb-export ensured that the device was bound to usbip-host
by checking whether the device was already bound to it, and, if not,
unbind from the other driver and binding to usbip-host. usb-export then
checks whether the usbip_status for the device is 1 (available) and
aborts if otherwise.
This means that if the device is already bound to usbip-host, and
usbip_status is either 2 (used) or 3 (error), usb-export will not
succeed.

This change makes sure the current driver always gets unbound, even if
it is usbip-host, before (re)binding to usbip-host. It should hence
ensure that usb-export can succeed even if usbip_status was 2 or 3.

Previously, if the VM to which the USB device got attached managed to
cause an error in usbip-host, it was not possible to use the usual tools
to connect again, or to another VM: because usbip_status was not 2
(used) anymore, cleanup would be called so that the tools viewed the
device as not connected anymore, but attempting to attach the device to
anything again would fail due to the reason described above. The user
would then need to manually unbind the usbip-host driver from the device
prior to trying again. This change fixes this.

One possible issue with this change could be that usb-export is intended
to fail should the device already be in use by usbip-host. As far as I can
see the tools like qvm-usb do not cause usb-export to be called if the
device is recognized as already being attached, so I think this change
could be reasonable. But it is of course up to the maintainers to decide
what the behavior of usb-export should be in that case.