### PR TITLE
Send events even when device is attached/detached by alternative method

### DIFF
--- a/src/usb-export
+++ b/src/usb-export
@@ -118,12 +118,16 @@ cleanup() {
     qubesdb-rm \
         /qubes-usb-devices/${safe_busid}/connected-to \
         /qubes-usb-devices/${safe_busid}/x-pid
+    # notify dom0
+    qubesdb-write /qubes-usb-devices ''
     exit
 }
 trap "cleanup" EXIT TERM
 qubesdb-write \
     /qubes-usb-devices/${safe_busid}/connected-to "${QREXEC_REMOTE_DOMAIN}" \
     /qubes-usb-devices/${safe_busid}/x-pid "$$"
+# notify dom0
+qubesdb-write /qubes-usb-devices ''
 
 # FIXME this is racy as hell!
 while sleep 1; do


### PR DESCRIPTION
Dom0 part already listen for device change events (qubesdb watch) and
also already keep a list of devices previously seen. Modify it a bit to
not only detect new devices, but also when existing device is
attached/deteched and send appropriate events. This will allow
qui-devices widget to update its state without polling.

This implements both attach and detach events, and both cases works now.

Fixes QubesOS/qubes-issues#5505