### PR TITLE
Clear cache when Qubes() object is getting destroyed

### DIFF
--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -392,3 +392,8 @@ class USBDeviceExtension(qubes.ext.Extension):
     def on_domain_shutdown(self, vm, _event, **_kwargs):
         # pylint: disable=unused-argument
         vm.fire_event('device-list-change:usb')
+
+    @qubes.ext.handler('qubes-close', system=True)
+    def on_qubes_close(self, app, event):
+        # pylint: disable=unused-argument
+        self.devices_cache.clear()


### PR DESCRIPTION
Commit a505ce7 "Send events even when device is attached/detached by
alternative method" introduced a local cache of usb devices. This cache
is valid only as long as Qubes() instance is. Normally it isn't an issue
(Qubes() object lifetime is bound to the qubesd process lifetime), but
during tests the object is created multiple times and cached objects
leaks between tests. Avoid this by clearing the cache whenever
Qubes().close() is called (and sends 'qubes-close' event).