### PR TITLE
tests: adjust delay after removing/detaching device

### DIFF
--- a/qubesusbproxy/tests.py
+++ b/qubesusbproxy/tests.py
@@ -172,6 +172,8 @@ class TC_00_USBProxy(qubes.tests.extra.ExtraTestCase):
             wait=True), 0,
             "Device connection failed")
         remove_usb_gadget(self.backend)
+        # FIXME: usb-export script may update qubesdb/disconnect with 1sec delay
+        time.sleep(2)
         self.assertEqual(self.frontend.run('lsusb -d 1234:1234', wait=True), 1,
             "Device not cleaned up")
         # TODO: check for kernel errors?
@@ -401,7 +403,7 @@ class TC_20_USBProxy_core3(qubes.tests.extra.ExtraTestCase):
         self.loop.run_until_complete(
             self.frontend.devices['usb'].detach(ass))
         # FIXME: usb-export script may update qubesdb with 1sec delay
-        time.sleep(2)
+        self.loop.run_until_complete(asyncio.sleep(2))
 
         self.assertIsNone(usb_dev.frontend_domain)
 
@@ -457,7 +459,7 @@ class TC_20_USBProxy_core3(qubes.tests.extra.ExtraTestCase):
 
         remove_usb_gadget(self.backend)
         # FIXME: usb-export script may update qubesdb with 1sec delay
-        self.loop.run_until_complete(asyncio.sleep(1))
+        self.loop.run_until_complete(asyncio.sleep(2))
 
         self.assertNotIn(self.usbdev_name, [str(dev) for dev in usb_list])
         self.assertNotEqual(self.frontend.run('lsusb -d 1234:1234',

--- a/src/usb-import
+++ b/src/usb-import
@@ -98,6 +98,20 @@ wait_for_attached() {
     udevadm settle
 }
 
+wait_for_detached() {
+    local port="$1"
+    local local_busid
+    local port_status
+    port_status=$(grep "^\(hs\|ss\)\? *$port" $DEVPATH/status)
+    local_busid=${port_status##* }
+    if [ -z "$local_busid" ]; then
+        return
+    fi
+    while [ -e /sys/bus/usb/devices/$local_busid ]; do
+        sleep 1
+    done
+}
+
 
 # negotiate parameters (field 'extra' reserved for future use)
 read untrusted_devid untrusted_speed untrusted_extra
@@ -151,3 +165,9 @@ wait_for_attached "$port"
 if [ -n "$SERVICE_ATTACH_PID" ]; then
     kill -HUP $SERVICE_ATTACH_PID
 fi
+
+# close stdin/out so the kernel is the only one with the socket reference
+exec <&- >&- 2>&-
+
+# do not end the process until device is detached, to not close the qrexec connection
+wait_for_detached "$port"


### PR DESCRIPTION
usb-export script checks only once a second if device wasn't detached
and then updates info in qubesdb. Adjust delay before checking if the
really happened to 2s, in all the places (some were missing it and some
used 1s). Also, for core3 tests always use asyncio sleep, to not block
other actions.