### PR TITLE
Fix checking if modprobe is available

### DIFF
--- a/qubesusbproxy/tests.py
+++ b/qubesusbproxy/tests.py
@@ -499,7 +499,7 @@ class TC_20_USBProxy_core3(qubes.tests.extra.ExtraTestCase):
             self.loop.run_until_complete(asyncio.sleep(1))
             timeout -= 1
             self.assertGreater(timeout, 0, 'timeout on device create')
-        self.loop.run_until_complete(asyncio.sleep(1))
+        self.loop.run_until_complete(asyncio.sleep(5))
         self.assertEqual(self.frontend.run('lsusb -d 1234:1234',
             wait=True), 0,
             "Device reconnection failed")

--- a/src/usb-import
+++ b/src/usb-import
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ -f "/usr/sbin/modprobe" ] && (modprobe vhci-hcd || exit 1)
+command -v modprobe >/dev/null && (modprobe vhci-hcd || exit 1)
 
 DEVPATH="/sys/devices/platform/vhci_hcd"
 if [ -d "${DEVPATH}.0" ]; then


### PR DESCRIPTION
Not every distro has /usr/sbin/modprobe, some has just /sbin/modprobe
(and not merged /usr). This is specifically the case for Debian template
upgraded from before buster.

Fixes QubesOS/qubes-issues#6868