### PR TITLE
Detach all devices before suspending

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ install-vm:
 	install qubes-rpc/qubes.USB $(DESTDIR)/etc/qubes-rpc
 	install -d $(DESTDIR)/usr/lib/qubes
 	install src/usb-* $(DESTDIR)/usr/lib/qubes
+	install -d $(DESTDIR)/etc/qubes/suspend-pre.d
+	ln -s ../../../usr/lib/qubes/usb-detach-all \
+		$(DESTDIR)/etc/qubes/suspend-pre.d/usb-detach-all.sh
 
 PYTHON2_SITELIB ?= $(shell python2 -c "from distutils.sysconfig import get_python_lib; print get_python_lib(0)")
 

--- a/rpm_spec/qubes-usb-proxy.spec.in
+++ b/rpm_spec/qubes-usb-proxy.spec.in
@@ -24,12 +24,13 @@ make install-vm DESTDIR=${RPM_BUILD_ROOT}
 
 %files
 #%%doc
-/usr/lib/qubes/usb-import
 /etc/qubes-rpc/qubes.USB
 /etc/qubes-rpc/qubes.USBAttach
 /etc/qubes-rpc/qubes.USBDetach
+/etc/qubes/suspend-pre.d/usb-detach-all.sh
 /usr/lib/qubes/usb-import
 /usr/lib/qubes/usb-export
+/usr/lib/qubes/usb-detach-all
 
 %changelog
 @CHANGELOG@

--- a/src/usb-detach-all
+++ b/src/usb-detach-all
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Detach all devices before suspend
+
+for dev in /sys/bus/usb/devices/*/usbip_sockfd; do
+    if [ -w "$dev" ]; then
+        echo -1 > "$dev"
+    fi
+done


### PR DESCRIPTION
Host controller drivers are detached on suspend, so all devices will be 
detached anyway. Do it before any domain is actually suspended to avoid 
deadlock.

Fixes QubesOS/qubes-issues#4657