### PR TITLE
 Support devices blocked by usbguard

### DIFF
--- a/qubes-rpc/qubes.USB
+++ b/qubes-rpc/qubes.USB
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/sh --
+set -eu
 
 service_arg="$1"
 if [ -z "$service_arg" ]; then
@@ -6,7 +7,8 @@ if [ -z "$service_arg" ]; then
     exit 1
 fi
 
-if [ "$(id -u)" -eq 0 ]; then
+uid=$(id -u)
+if [ "$uid" -eq 0 ]; then
     exec /usr/lib/qubes/usb-export "$service_arg"
 else
     # preserve QREXEC_AGENT_PID variable

--- a/qubes-rpc/qubes.USBAttach
+++ b/qubes-rpc/qubes.USBAttach
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/sh --
+set -eu
 
 read domain busid
 statefile="/var/run/qubes/usb-import-${domain}-${busid}.state"
-export SERVICE_ATTACH_PID=$$
+export "SERVICE_ATTACH_PID=$$"
 trap "exit 0" HUP
 # don't let qrexec-client-vm keeping open FDs - that would prevent
 # qubes.USBAttach service to end.
@@ -11,11 +12,9 @@ trap "exit 0" HUP
 qrexec-client-vm "$domain" "qubes.USB+$busid" \
     /usr/lib/qubes/usb-import "$statefile" \
     </dev/null >/dev/null 2>/dev/null &
-wait $!
-remote_retcode=$?
 # prefer reporting remote error code
-if [ "$remote_retcode" -gt 0 ]; then
-    exit $remote_retcode
-else
+if wait "$!"; then
     exit 1
+else
+    exit "$?"
 fi

--- a/qubes-rpc/qubes.USBDetach
+++ b/qubes-rpc/qubes.USBDetach
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/sh --
+set -eu
 
 read domain busid
 if [ -z "$busid" ]; then
@@ -23,15 +24,16 @@ else
         echo "Device $busid from domain $domain not attached!" >&2
         exit 1
     fi
-    port=$(cat "$statefile")
-    port_status=$(grep "^\(hs\|ss\)\? *$port" $DEVPATH/status)
-    if [ -z "$port_status" ]; then
+    read -r port < "$statefile"
+    if ! port_status=$(grep -- "^\\(hs\\|ss\\)\\? *$port" "$DEVPATH/status"); then
+        status=$?
         echo "Failed to find USB port '$port'" >&2
-        exit 1
+        exit "$status"
     fi
     local_busid=${port_status##* }
-    echo $port > $DEVPATH/detach && rm $statefile
-    while [ -e /sys/bus/usb/devices/$local_busid ]; do
+    echo "$port" > "$DEVPATH/detach"
+    rm -f -- "$statefile"
+    while [ -e "/sys/bus/usb/devices/$local_busid" ]; do
         sleep 0.2
     done
 fi

--- a/src/usb-export
+++ b/src/usb-export
@@ -86,6 +86,10 @@ if [ -z "$devpath" ]; then
 fi
 
 busid=${devpath##*/}
+if ! [[ "$busid" =~ ^[0-9]+-[0-9]+$ ]]; then
+    printf 'Invalid bus path %q\n' "$devpath" >&2
+    exit 1
+fi
 pidfile="/var/run/qubes/usb-export-$busid.pid"
 
 modprobe usbip-host
@@ -107,6 +111,11 @@ read status < "$devpath/usbip_status"
 if [ "$status" -ne "$SDEV_ST_AVAILABLE" ]; then
     printf 'Device %s not available!\n' "$devpath" >&2
     exit 1
+fi
+
+# Allow the device.
+if command -v usbguard > /dev/null; then
+    usbguard allow-device "via-port \"$busid\"" || :
 fi
 
 read -r busnum < "$devpath/busnum"

--- a/src/usb-export
+++ b/src/usb-export
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash --
+set -euo pipefail
 
 SYS_USB_DEVICES=/sys/bus/usb/devices
 SYS_USBIP_HOST=/sys/bus/usb/drivers/usbip-host
@@ -8,7 +9,7 @@ SDEV_ST_AVAILABLE=1
 SDEV_ST_USED=2
 SDEV_ST_ERROR=3
 
-usage() {
+usage () {
     echo "$0 device"
 }
 
@@ -17,17 +18,18 @@ if [ "$#" -lt 1 ]; then
     exit 1
 fi
 
-find_by_bus_dev() {
-    local busnum=$1
-    local devnum=$2
-    for devpath in $SYS_USB_DEVICES/*; do
-        if ! [ -e $devpath/busnum -a -e $devpath/devnum ]; then
+find_by_bus_dev () {
+    local busnum="$1"
+    local devnum="$2"
+    local tmp_busnum tmp_devnum
+    for devpath in "$SYS_USB_DEVICES"/*; do
+        if [ ! -e "$devpath/busnum" ] && [ ! -e $devpath/devnum ]; then
             # skip individual interfaces etc
             continue
         fi
-        if [ "$busnum" -eq "$(cat $devpath/busnum)" -a \
-                "$devnum" -eq "$(cat $devpath/devnum)" ]; then
-            echo $devpath
+        read -r tmp_busnum < "$devpath/busnum"
+        read -r tmp_devnum < "$devpath/devnum"
+        if [ "$busnum" -eq "$tmp_busnum" ] && [ "$devnum" -eq "$tmp_devnum" ]; then
             return
         fi
     done
@@ -36,34 +38,40 @@ find_by_bus_dev() {
 }
 
 # Resolve device name to sysfs path
-resolve_device() {
+resolve_device () {
     device="$1"
+    local lsusb_output_array IFS=$'\n' lsusb_output
     # handle different device formats
     case $device in
         0x*.0x*)
-            device=$(echo "$device" | tr . :)
+            device=${device//./:}
             # make sure there is only one matching device
-            if [ $(lsusb -d $device | wc -l) -ne 1 ]; then
+            # Example: Bus 003 Device 002: ID 05e3:0608 Genesys Logic, Inc. Hub
+            set -f # suppress globbing
+            lsusb_output=$(lsusb -d "$device")
+            lsusb_output_array=($lsusb_output)
+            set +f
+            if [ "${#lsusb_output_array[@]}" -ne 1 ]; then
                 echo "Multiple or no devices matching $device, aborting!" >&2
                 exit 1
             fi
-            # Example: Bus 003 Device 002: ID 05e3:0608 Genesys Logic, Inc. Hub
-            lsusb_output="$(lsusb -d $device)"
             bus=$(echo "$lsusb_output" | cut -d ' ' -f 2)
             dev=$(echo "$lsusb_output" | cut -d ' ' -f 4 | tr -d :)
             find_by_bus_dev "$bus" "$dev"
             ;;
         *-*)
             # a single device, but NOT a specific interface
-            if echo "$device" | grep -q :; then
+            case $device in
+            *:*)
                 echo "You cannot export a specific device interface!" >&2
                 exit 1
-            fi
+                ;;
+            esac
             if ! [ -d "$SYS_USB_DEVICES/$device" ]; then
                 echo "No such device: $device" >&2
                 exit 1
             fi
-            echo "$SYS_USB_DEVICES/$device"
+            devpath="$SYS_USB_DEVICES/$device"
             ;;
         *)
             echo "Invalid device format: $device" >&2
@@ -72,68 +80,67 @@ resolve_device() {
     esac
 }
 
-devpath=$(resolve_device "$1")
+resolve_device "$1"
 if [ -z "$devpath" ]; then
     exit 1
 fi
 
-pidfile="/var/run/qubes/usb-export-$(basename $devpath).pid"
+busid=${devpath##*/}
+pidfile="/var/run/qubes/usb-export-$busid.pid"
 
-modprobe usbip-host || exit 1
+modprobe usbip-host
 
 # Request that both IN and OUT be handled on a single (stdin) socket
 kill -USR1 "$QREXEC_AGENT_PID" || exit 1
 
-busid=$(basename "$devpath")
 # Unbind the device from the driver
 if [ -d "$devpath/driver" ]; then
-    echo $busid > $devpath/driver/unbind || exit 1
+    printf %s "$busid" > "$devpath/driver/unbind" || exit 1
 fi
 
 # Bind to the usbip-host driver
-echo -n add $busid > $SYS_USBIP_HOST/match_busid || exit 1
-echo $busid > $SYS_USBIP_HOST/bind || exit 1
+printf 'add %s' "$busid" > "$SYS_USBIP_HOST/match_busid" || exit 1
+echo "$busid" > "$SYS_USBIP_HOST/bind" || exit 1
 
 # One more safety check - make sure the device is available
-if [ "$(cat $devpath/usbip_status)" -ne $SDEV_ST_AVAILABLE ]; then
-    echo "Device $devpath not available!" >&2
+read status < "$devpath/usbip_status"
+if [ "$status" -ne "$SDEV_ST_AVAILABLE" ]; then
+    printf 'Device %s not available!\n' "$devpath" >&2
     exit 1
 fi
 
-busnum=$(cat $devpath/busnum)
-devnum=$(cat $devpath/devnum)
-devid=$(( $busnum << 16 | $devnum ))
-speed=$(cat $devpath/speed)
+read -r busnum < "$devpath/busnum"
+read -r devnum < "$devpath/devnum"
+devid=$(( busnum << 16 | devnum ))
+read -r speed < "$devpath/speed"
 
 # Send device details to the other end (usb-import script)
-echo "$devid" "$speed" >&0
+printf '%s %s\n' "$devid" "$speed" >&0
 
-echo 0 > $devpath/usbip_sockfd || exit 1
-exec <&-
+echo 0 > "$devpath/usbip_sockfd" || exit 1
+exec < /dev/null
 
-echo $$ > "$pidfile"
-safe_busid=$(echo ${busid} | tr :. _)
+echo "$$" > "$pidfile"
+safe_busid=${busid//:/_}
+safe_busid=${safe_busid//./_}
 
 cleanup() {
     qubesdb-rm \
         /qubes-usb-devices/${safe_busid}/connected-to \
-        /qubes-usb-devices/${safe_busid}/x-pid
-    # notify dom0
-    qubesdb-write /qubes-usb-devices ''
+        /qubes-usb-devices/${safe_busid}/x-pid \
+        qubesdb-write /qubes-usb-devices ''
     exit
 }
 trap "cleanup" EXIT TERM
 qubesdb-write \
-    /qubes-usb-devices/${safe_busid}/connected-to "${QREXEC_REMOTE_DOMAIN%-dm}" \
-    /qubes-usb-devices/${safe_busid}/x-pid "$$"
-# notify dom0
-qubesdb-write /qubes-usb-devices ''
+    "/qubes-usb-devices/${safe_busid}/connected-to" "${QREXEC_REMOTE_DOMAIN%-dm}" \
+    "/qubes-usb-devices/${safe_busid}/x-pid" "$$" \
+    /qubes-usb-devices ''
 
 # FIXME this is racy as hell!
 while sleep 1; do
     # wait while device is "used"
-    if [ "$(cat $devpath/usbip_status 2>/dev/null || echo 0)" -ne $SDEV_ST_USED ]; then
-        break
-    fi
+    read -r status < "$devpath/usbip_status"
+    if [ "$status" -ne "$SDEV_ST_USED" ]; then break; fi
 done
 # cleanup will be called automatically

--- a/src/usb-import
+++ b/src/usb-import
@@ -1,6 +1,7 @@
-#!/bin/sh
+#!/bin/sh --
 
-command -v modprobe >/dev/null && (modprobe vhci-hcd || exit 1)
+set -eu
+if command -v modprobe >/dev/null; then modprobe vhci-hcd; fi
 
 DEVPATH="/sys/devices/platform/vhci_hcd"
 if [ -d "${DEVPATH}.0" ]; then
@@ -39,7 +40,7 @@ if [ -n "$SERVICE_ATTACH_PID" ]; then
     # use stderr of qubes.USBAttach service call
     # otherwise it would be redirected to /dev/null
     # (see comment in qubes.USBAttach)
-    exec 2>/proc/$SERVICE_ATTACH_PID/fd/2
+    exec 2>"/proc/$SERVICE_ATTACH_PID/fd/2"
 fi
 
 # based on linux/tools/usb/usbip/libsrc/vhci_driver.c
@@ -51,25 +52,21 @@ find_port() {
         if [ "$hub" = "port" ] || [ "$hub" = "prt" ]; then
             # old header:
             #   port sta spd bus dev socket local_busid
-            if [ "$requested_hub" = "ss" ]; then
-                echo "USB SuperSpeed require kernel >= 4.13" >&2
-                exit 1
-            fi
-            old_header=1
-            continue
+            echo "kernel < 4.13 no longer supported" >&2
+            exit 1
         elif [ "$hub" = "hub" ]; then
             # new header
             #   hub port sta spd bus dev socket local_busid
             continue
         elif [ -n "$old_header" ] && [ "$port" -eq $VDEV_ST_NULL ]; then
             # port column in old header
-            echo $hub
-            return 0
+            echo "kernel < 4.13 no longer supported" >&2
+            exit 1
         elif [ -z "$old_header" ] && [ "$hub" = "$requested_hub" ] && [ "$sta" -eq $VDEV_ST_NULL ]; then
-            echo $port
+            echo "$port"
             return 0
         fi
-    done < $DEVPATH/status
+    done < "$DEVPATH/status"
     ERROR "No unused port found!"
 }
 
@@ -85,9 +82,12 @@ wait_for_attached() {
     local port="$1"
     local local_busid="0-0"
     local timeout=25
-    while [ ! -e /sys/bus/usb/devices/$local_busid ]; do
+    while [ ! -e "/sys/bus/usb/devices/$local_busid" ]; do
         sleep 0.2
-        port_status=$(grep "^\(hs\|ss\)\? *$port" $DEVPATH/status)
+        if ! port_status=$(grep -- "^\\(hs\\|ss\\)\\? *$port" "$DEVPATH/status"); then
+            local status="$?"
+            if [[ "$status" -gt 1 ]]; then exit "$status"; fi
+        fi
         local_busid=${port_status##* }
         timeout=$(( timeout - 1 ))
         if [ "$timeout" -le 0 ]; then
@@ -102,12 +102,15 @@ wait_for_detached() {
     local port="$1"
     local local_busid
     local port_status
-    port_status=$(grep "^\(hs\|ss\)\? *$port" $DEVPATH/status)
+    if ! port_status=$(grep -- "^\\(hs\\|ss\\)\\? *$port" "$DEVPATH/status"); then
+        local status="$?"
+        if [[ "$status" -gt 1 ]]; then exit "$status"; fi
+    fi
     local_busid=${port_status##* }
     if [ -z "$local_busid" ]; then
         return
     fi
-    while [ -e /sys/bus/usb/devices/$local_busid ]; do
+    while [ -e "/sys/bus/usb/devices/$local_busid" ]; do
         sleep 1
     done
 }
@@ -117,7 +120,7 @@ wait_for_detached() {
 read untrusted_devid untrusted_speed untrusted_extra
 
 # check for unexpected EOF
-if [ -z "$untrusted_devid" -a -z "$untrusted_speed" ]; then
+if [ -z "$untrusted_devid" ] && [ -z "$untrusted_speed" ]; then
     echo "No device info received, connection failed, check backend side for details" >&2
     exit 1
 fi
@@ -157,7 +160,7 @@ kill -USR1 "$QREXEC_AGENT_PID" || exit 1
 
 attach "$port" "$devid" "$speed" || exit 1
 
-echo $port >"$statefile"
+echo "$port" >"$statefile"
 
 # wait for device really being attached
 wait_for_attached "$port"
@@ -168,7 +171,7 @@ if [ -n "$SERVICE_ATTACH_PID" ]; then
 fi
 
 # close stdin/out so the kernel is the only one with the socket reference
-exec <&- >&- 2>&-
+exec < /dev/null >/dev/null 2>&1
 
 # do not end the process until device is detached, to not close the qrexec connection
 wait_for_detached "$port"


### PR DESCRIPTION
This uses the via-port syntax to ensure that usbguard is authorizing the
device that is being exported.  The device is not authorized until after
being bound to usbip-host, ensuring that other (less secure) drivers are
not loaded.

Fixes: https://github.com/QubesOS/qubes-issues/issues/6331