### PR TITLE
Remove too strict validation of a trusted parameter

### DIFF
--- a/src/usb-export
+++ b/src/usb-export
@@ -86,10 +86,6 @@ if [ -z "$devpath" ]; then
 fi
 
 busid=${devpath##*/}
-if ! [[ "$busid" =~ ^[0-9]+-[0-9]+$ ]]; then
-    printf 'Invalid bus path %q\n' "$devpath" >&2
-    exit 1
-fi
 pidfile="/var/run/qubes/usb-export-$busid.pid"
 
 modprobe usbip-host


### PR DESCRIPTION
It comes from a local lookup in sysfs, based on an argument that was
approved by qrexec policy already, there is no need for extra validation
(that turned out to be buggy).

Fixes QubesOS/qubes-issues#9104