### PR TITLE
Fix typo in variable when stderr ends with a comma

### DIFF
--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -645,7 +645,7 @@ class USBDeviceExtension(qubes.ext.Extension):
                     sanitized_stderr = ''.join(
                         [chr(c) for c in sanitized_stderr if 0x20 <= c < 0x80])
                     if sanitized_stderr.endswith(", "):
-                        sanitized_stderr = santizied_stderr[:-2] + "."
+                        sanitized_stderr = sanitized_stderr[:-2] + "."
                     raise QubesUSBException(
                         'Device attach failed: {}'.format(sanitized_stderr))
         finally:


### PR DESCRIPTION
I recently encountered an error while attaching a device to a different qube. The error cause was this typo.