### PR TITLE
rpm: add BR for directory ownership check

### DIFF
--- a/rpm_spec/qubes-usb-proxy.spec.in
+++ b/rpm_spec/qubes-usb-proxy.spec.in
@@ -9,6 +9,10 @@ URL:		https://www.qubes-os.org/
 BuildArch:  noarch
 
 BuildRequires: make
+%if 0%{?is_opensuse}
+# for directory ownership
+BuildRequires: qubes-core-agent
+%endif
 Requires:   usbutils
 
 Source0: %{name}-%{version}.tar.gz


### PR DESCRIPTION
openSUSE checks for directory ownership at rpm build time, so some
runtime dependencies needs to be installed at build time too.

QubesOS/qubes-issues#6567