### PR TITLE
Fix clearing available devices cache on domain shutdown

### DIFF
--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -776,6 +776,7 @@ class USBDeviceExtension(qubes.ext.Extension):
     async def on_domain_shutdown(self, vm, _event, **_kwargs):
         # pylint: disable=unused-argument
         vm.fire_event("device-list-change:usb")
+        utils.device_list_change(self, {}, vm, None, USBDevice)
 
     @qubes.ext.handler("qubes-close", system=True)
     def on_qubes_close(self, app, event):


### PR DESCRIPTION
Call utils.device_list_change() on domain shutdown, for two reasons:
- generate relevant device-removed events for all devices provided by
this VM
- do not swallow device-added events on startup (if they were cached as
present before)

QubesOS/qubes-issues#8537