### PR TITLE
core3ext: reattach assigned USB devices on resume from suspend

### DIFF
--- a/qubesusbproxy/tests.py
+++ b/qubesusbproxy/tests.py
@@ -22,6 +22,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 import time
+import uuid
 import unittest
 from unittest import mock
 from unittest.mock import Mock, AsyncMock
@@ -620,6 +621,7 @@ class TestVM(qubes.tests.TestEmitter):
     def __init__(self, qdb, running=True, name="test-vm", **kwargs):
         super().__init__(**kwargs)
         self.name = name
+        self.uuid = uuid.uuid4()
         self.klass = "AdminVM" if name == "dom0" else "AppVM"
         self.icon = "red"
         self.untrusted_qdb = TestQubesDB(qdb)


### PR DESCRIPTION
This patch ensures USB devices are reattached on resume, which is necessary for S0ix since we don't detach the USB controller drivers and hence the udev rules aren't retriggered automatically. I've relocated the attachment logic into `_auto_attach_devices`, which is now shared between the domain-start and domain-resumed handlers.

I've also added a new event, domain-resumed, in core-admin to support this since domain-unpaused isn't sufficient for our needs. That PR can be found here and is a dependency for this change: https://github.com/QubesOS/qubes-core-admin/pull/725