### PR TITLE
q-dev: avoid zombie USB device

### DIFF
--- a/qubes-rpc/qubes.USBDetach
+++ b/qubes-rpc/qubes.USBDetach
@@ -9,6 +9,18 @@ if [ -z "$busid" ]; then
     usbip_sockfd="/sys/bus/usb/devices/$busid/usbip_sockfd"
     if [ -w "$usbip_sockfd" ]; then
         echo -1 > "$usbip_sockfd"
+
+        # avoid zombie usb (visible from backend but held by usbip driver)
+        # disconnect usbip driver
+        if ! echo "$busid" > "/sys/bus/usb/drivers/usbip-host/unbind" 2>/dev/null; then
+            echo "Failed to unbind USB device $busid from usbip-host driver" >&2
+            exit 1
+        fi
+        # reload driver to make it available in backend again
+        if ! echo "$busid" > "/sys/bus/usb/drivers_probe"; then
+            echo "Failed to reload USB device $busid driver" >&2
+            exit 1
+        fi
     else
         echo "Device $busid not found or not attached to any VM!" >&2
         exit 1

--- a/qubes-rpc/qubes.USBDetach
+++ b/qubes-rpc/qubes.USBDetach
@@ -16,7 +16,14 @@ if [ -z "$busid" ]; then
             echo "Failed to unbind USB device $busid from usbip-host driver" >&2
             exit 1
         fi
-        # reload driver to make it available in backend again
+
+        # reset
+        if ! /usr/lib/qubes/usb-reset "/sys/bus/usb/devices/$busid"; then
+            echo "Failed to reset USB device $busid" >&2
+            exit 1
+        fi
+
+        # reload driver to make it fully available in backend again
         if ! echo "$busid" > "/sys/bus/usb/drivers_probe"; then
             echo "Failed to reload USB device $busid driver" >&2
             exit 1


### PR DESCRIPTION
After detaching from the frontend VM, the USB device remained under the control of the usbip driver. This caused the device to remain visible in the backend vm but unusable there (zombie). The issue is that, for example, a USB stick would not expose its partitions to the backend, preventing us from using them (e.g. attaching partition to frontend vm).