### PR TITLE
Validate with cheap methods before running check

### DIFF
--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -226,7 +226,7 @@ class USBDevice(DeviceInfo):
 
     def _load_interfaces_from_qubesdb(self) -> List[DeviceInterface]:
         result = [DeviceInterface.unknown()]
-        if not self.backend_domain.is_running():
+        if not getattr(self.backend_domain, "untrusted_qdb"):
             # don't cache this value
             return result
         untrusted_interfaces: bytes = self.backend_domain.untrusted_qdb.read(
@@ -254,7 +254,7 @@ class USBDevice(DeviceInfo):
             "name": unknown,
             "serial": unknown,
         }
-        if not self.backend_domain.is_running():
+        if not getattr(self.backend_domain, "untrusted_qdb"):
             # don't cache this value
             return result
         untrusted_device_desc: bytes = self.backend_domain.untrusted_qdb.read(
@@ -342,7 +342,7 @@ class USBDevice(DeviceInfo):
 
     @property
     def attachment(self):
-        if not self.backend_domain.is_running():
+        if not getattr(self.backend_domain, "untrusted_qdb"):
             return None
         untrusted_connected_to = self.backend_domain.untrusted_qdb.read(
             self._qdb_path + "/connected-to"
@@ -614,13 +614,13 @@ class USBDeviceExtension(qubes.ext.Extension):
     def on_device_list_usb(self, vm, event):
         # pylint: disable=unused-argument
 
-        if not vm.is_running() or not hasattr(vm, "untrusted_qdb"):
-            return
-
         if (
             isinstance(vm, qubes.vm.adminvm.AdminVM)
             and not self.usb_proxy_installed_in_dom0
         ):
+            return
+
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         untrusted_dev_list = vm.untrusted_qdb.list("/qubes-usb-devices/")
@@ -640,7 +640,7 @@ class USBDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-get:usb")
     def on_device_get_usb(self, vm, event, port_id):
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         if vm.untrusted_qdb.list(
@@ -651,7 +651,11 @@ class USBDeviceExtension(qubes.ext.Extension):
     @staticmethod
     def get_all_devices(app):
         for vm in app.domains:
-            if not vm.is_running() or not hasattr(vm, "devices"):
+            if (
+                not hasattr(vm, "devices")
+                or "usb" not in vm.devices
+                or not vm.is_running()
+            ):
                 continue
 
             for dev in vm.devices["usb"]:
@@ -666,7 +670,7 @@ class USBDeviceExtension(qubes.ext.Extension):
             return
 
         for dev in self.get_all_devices(vm.app):
-            if dev.attachment == vm:
+            if dev.attachment is vm:
                 yield (dev, {})
 
     @qubes.ext.handler("device-pre-attach:usb")
@@ -678,7 +682,7 @@ class USBDeviceExtension(qubes.ext.Extension):
                 "USB device attach does not support user options"
             )
 
-        if not vm.is_running() or vm.qid == 0:
+        if vm.qid == 0 or not vm.is_running():
             # print(f"Qube is not running, skipping attachment of {device}",
             #       file=sys.stderr)
             return
@@ -740,7 +744,7 @@ class USBDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-pre-detach:usb")
     async def on_device_detach_usb(self, vm, event, port):
         # pylint: disable=unused-argument
-        if not vm.is_running() or vm.qid == 0:
+        if vm.qid == 0 or not vm.is_running():
             return
 
         for attached, _options in self.on_device_list_attached(vm, event):

--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -654,7 +654,7 @@ class USBDeviceExtension(qubes.ext.Extension):
             if (
                 not hasattr(vm, "devices")
                 or "usb" not in vm.devices
-                or not vm.is_running()
+                or not getattr(vm, "untrusted_qdb")
             ):
                 continue
 
@@ -666,7 +666,7 @@ class USBDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-list-attached:usb")
     def on_device_list_attached(self, vm, event, **kwargs):
         # pylint: disable=unused-argument
-        if not vm.is_running():
+        if not getattr(vm, "untrusted_qdb"):
             return
 
         for dev in self.get_all_devices(vm.app):
@@ -682,7 +682,7 @@ class USBDeviceExtension(qubes.ext.Extension):
                 "USB device attach does not support user options"
             )
 
-        if vm.qid == 0 or not vm.is_running():
+        if vm.qid == 0 or not getattr(vm, "untrusted_qdb"):
             # print(f"Qube is not running, skipping attachment of {device}",
             #       file=sys.stderr)
             return
@@ -744,7 +744,7 @@ class USBDeviceExtension(qubes.ext.Extension):
     @qubes.ext.handler("device-pre-detach:usb")
     async def on_device_detach_usb(self, vm, event, port):
         # pylint: disable=unused-argument
-        if vm.qid == 0 or not vm.is_running():
+        if vm.qid == 0 or not getattr(vm, "untrusted_qdb"):
             return
 
         for attached, _options in self.on_device_list_attached(vm, event):

--- a/qubesusbproxy/utils.py
+++ b/qubesusbproxy/utils.py
@@ -77,7 +77,7 @@ def device_list_change(
 
     to_attach: Dict[str, Dict] = {}
     for front_vm in vm.app.domains:
-        if not front_vm.is_running():
+        if not getattr(front_vm, "untrusted_qdb"):
             continue
         for assignment in reversed(
             sorted(front_vm.devices[devclass].get_assigned_devices())


### PR DESCRIPTION
For: https://github.com/QubesOS/qubes-issues/issues/10569
For: https://github.com/QubesOS/qubes-issues/issues/9902

---

I haven't tested this yet. I am implictly relying that `untrusted_qdb` does the check `is_running()` if it's empty.

On other places, use cheaper methods like key in dictionary before even checking if domain is running. This is important for the loop through all domains.

I will use cProfile to test if there are improvements and if less calls are made to `is_running()`.

To reduce even more the number of calls, I'd like to change this: https://github.com/QubesOS/qubes-core-admin/blob/18afb70d78afabb7ca9da90a7579138318caa4d0/qubes/vm/qubesvm.py#L1088, from `is_running()` to something else, maybe without relying on libvirt.