### PR TITLE
device busy attribute to prevent attaching devices whose children are in use

### DIFF
--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -393,7 +393,8 @@ class USBDevice(DeviceInfo):
     def busy(self) -> bool:
         """
         Is this device busy?  A device is considered busy if any of its children
-        are in use (e.g., a child device is currently attached).
+        are in use: attached to a VM or used locally in the backend VM
+        (mounted, part of a device-mapper, enabled swap).
         """
         if self._busy is None:
             if not self.backend_domain.is_running():
@@ -734,8 +735,7 @@ class USBDeviceExtension(qubes.ext.Extension):
 
         if device.busy:
             raise qubes.exc.QubesValueError(
-                f"Device {device} is busy: "
-                "check if a child device is currently attached to other VM"
+                f"Device {device} is busy: it or one of its children is in use."
             )
 
         stubdom_qrexec = (

--- a/qubesusbproxy/core3ext.py
+++ b/qubesusbproxy/core3ext.py
@@ -42,6 +42,7 @@ try:
     from qubes.device_protocol import DeviceInfo
     from qubes.device_protocol import DeviceInterface
     from qubes.device_protocol import Port
+    from qubes.device_protocol import qbool_untrusted_busy
     from qubes.ext import utils
 
     def get_assigned_devices(devices):
@@ -73,6 +74,7 @@ except ImportError:
             self._serial = None
             # `_load_interfaces_from_qubesdb` will never be called
             self._interfaces = "?******"
+            self._busy = None
 
         @property
         def frontend_domain(self):
@@ -90,6 +92,11 @@ except ImportError:
 
     def get_assigned_devices(devices):
         yield from devices.assignments(persistent=True)
+
+    def qbool_untrusted_busy(untrusted_busy, log=None) -> bool:
+        # legacy fallback: absent means free, any value means busy
+        # pylint: disable=unused-argument
+        return untrusted_busy is not None
 
 
 import qubes.devices
@@ -126,6 +133,18 @@ class USBDevice(DeviceInfo):
         self._qdb_path = "/qubes-usb-devices/" + self._qdb_ident
         self._vendor_id: Optional[str] = None
         self._product_id: Optional[str] = None
+
+    def mark_busy(self, busy: bool) -> None:
+        """Write or clear the busy marker in the backend VM's QDB."""
+        key = f"{self._qdb_path}/busy"
+        if not busy:
+            try:
+                self.backend_domain.untrusted_qdb.rm(key)
+            except Exception:  # pylint: disable=broad-except
+                pass
+        else:
+            self.backend_domain.untrusted_qdb.write(key, b"True")
+        self._busy = busy
 
     @property
     def vendor(self) -> str:
@@ -371,6 +390,24 @@ class USBDevice(DeviceInfo):
         return connected_to
 
     @property
+    def busy(self) -> bool:
+        """
+        Is this device busy?  A device is considered busy if any of its children
+        are in use (e.g., a child device is currently attached).
+        """
+        if self._busy is None:
+            if not self.backend_domain.is_running():
+                # don't cache this value
+                return False
+            untrusted_busy = self.backend_domain.untrusted_qdb.read(
+                self._qdb_path + "/busy"
+            )
+            self._busy = qbool_untrusted_busy(
+                untrusted_busy, self.backend_domain.log
+            )
+        return self._busy
+
+    @property
     def device_id(self) -> str:
         """
         Get identification of a device not related to port.
@@ -538,6 +575,8 @@ class USBDeviceExtension(qubes.ext.Extension):
                         continue
                     if device.attachment:
                         continue
+                    if device.busy:
+                        continue
                     if not assignment.matches(device):
                         print(
                             "Unrecognized identity, skipping attachment of device "
@@ -643,9 +682,8 @@ class USBDeviceExtension(qubes.ext.Extension):
         if not vm.is_running():
             return
 
-        if vm.untrusted_qdb.list(
-            "/qubes-usb-devices/" + port_id.replace(".", "_")
-        ):
+        qdb_ident = port_id.replace(".", "_")
+        if vm.untrusted_qdb.list(f"/qubes-usb-devices/{qdb_ident}"):
             yield USBDevice(Port(vm, port_id, "usb"))
 
     @staticmethod
@@ -692,6 +730,12 @@ class USBDeviceExtension(qubes.ext.Extension):
         if device.attachment:
             raise qubes.exc.DeviceAlreadyAttached(
                 f"Device {device} already attached to {device.attachment}"
+            )
+
+        if device.busy:
+            raise qubes.exc.QubesValueError(
+                f"Device {device} is busy: "
+                "check if a child device is currently attached to other VM"
             )
 
         stubdom_qrexec = (

--- a/qubesusbproxy/tests.py
+++ b/qubesusbproxy/tests.py
@@ -569,6 +569,12 @@ class TestQubesDB:
     def read(self, key):
         return self._data.get(key, None)
 
+    def write(self, key, value):
+        self._data[key] = value
+
+    def rm(self, key):
+        self._data.pop(key, None)
+
     def list(self, prefix):
         return [key for key in self._data if key.startswith(prefix)]
 
@@ -994,6 +1000,86 @@ class TC_30_USBProxy_core3(qubes.tests.QubesTestCase):
 
     def test_023_on_startup_already_attached(self):
         back, front = self.added_assign_setup(attachment="sys-usb")
+
+        exp_dev = qubesusbproxy.core3ext.USBDevice(Port(back, "1-1", "usb"))
+        assmnt = DeviceAssignment(
+            VirtualDevice(exp_dev.port, exp_dev.device_id), mode="auto-attach"
+        )
+
+        front.devices["usb"]._assigned.append(assmnt)
+        back.devices["usb"]._exposed.append(exp_dev)
+
+        loop = asyncio.get_event_loop()
+        with mock.patch.object(
+            self.ext, "attach_and_notify"
+        ) as attach_and_notify:
+            loop.run_until_complete(self.ext.on_domain_start(front, None))
+            attach_and_notify.assert_not_called()
+
+    def test_030_list_busy_devices(self):
+        qdb = get_qdb()
+        qdb["/qubes-usb-devices/1-1/busy"] = b"True"
+        back_vm = TestVM(qdb=qdb, name="sys-usb")
+
+        devices = {
+            dev.port_id: dev for dev in self.ext.on_device_list_usb(back_vm, "")
+        }
+        self.assertTrue(devices["1-1"].busy)
+        self.assertFalse(devices["1-2"].busy)
+
+    def test_031_device_get_busy(self):
+        qdb = get_qdb()
+        qdb["/qubes-usb-devices/1-1/busy"] = b"True"
+        back_vm = TestVM(qdb=qdb, name="sys-usb")
+
+        devices = list(self.ext.on_device_get_usb(back_vm, "", "1-1"))
+        self.assertEqual(len(devices), 1)
+        self.assertTrue(devices[0].busy)
+
+        devices = list(self.ext.on_device_get_usb(back_vm, "", "1-2"))
+        self.assertEqual(len(devices), 1)
+        self.assertFalse(devices[0].busy)
+
+    def test_032_device_get_invalid_busy(self):
+        # an unparsable value is treated as busy
+        qdb = get_qdb()
+        qdb["/qubes-usb-devices/1-1/busy"] = b"garbage"
+        back_vm = TestVM(qdb=qdb, name="sys-usb")
+
+        devices = list(self.ext.on_device_get_usb(back_vm, "", "1-1"))
+        self.assertEqual(len(devices), 1)
+        self.assertTrue(devices[0].busy)
+
+    def test_033_attach_busy_device_refused(self):
+        back, front = self.added_assign_setup()
+        back.untrusted_qdb.write("/qubes-usb-devices/1-1/busy", b"True")
+        front.qid = 1
+
+        device = qubesusbproxy.core3ext.USBDevice(Port(back, "1-1", "usb"))
+        back.devices["usb"]._exposed.append(device)
+
+        loop = asyncio.get_event_loop()
+        with self.assertRaises(qubes.exc.QubesValueError):
+            loop.run_until_complete(
+                self.ext.on_device_attach_usb(front, "", device, options={})
+            )
+
+    def test_034_mark_busy(self):
+        back_vm = TestVM(qdb=get_qdb(), name="sys-usb")
+        device = qubesusbproxy.core3ext.USBDevice(Port(back_vm, "1-1", "usb"))
+
+        device.mark_busy(True)
+        self.assertEqual(
+            back_vm.untrusted_qdb.read("/qubes-usb-devices/1-1/busy"), b"True"
+        )
+        device.mark_busy(False)
+        self.assertIsNone(
+            back_vm.untrusted_qdb.read("/qubes-usb-devices/1-1/busy")
+        )
+
+    def test_035_on_startup_busy_not_auto_attached(self):
+        back, front = self.added_assign_setup()
+        back.untrusted_qdb.write("/qubes-usb-devices/1-1/busy", b"True")
 
         exp_dev = qubesusbproxy.core3ext.USBDevice(Port(back, "1-1", "usb"))
         assmnt = DeviceAssignment(

--- a/qubesusbproxy/utils.py
+++ b/qubesusbproxy/utils.py
@@ -87,6 +87,10 @@ def device_list_change(
                     assignment.matches(device)
                     and device.port_id in added
                     and device.port_id not in attached
+                    # Do not auto-attach busy devices: attach would be
+                    # refused anyway, leaving an unhandled exception.
+                    # For backward compatibility we use `getattr`.
+                    and not getattr(device, "busy", False)
                 ):
                     frontends = to_attach.get(device.port_id, {})
                     # make it unique


### PR DESCRIPTION
Add busy mechanism as the BlockDevice bt for USBDevice:, see: QubesOS/qubes-core-admin/pull/840
a USB device is refused for attachment while one of its exposed block sub-devices is used.

- `USBDevice.busy` reads `/qubes-usb-devices/<id>/busy` the same way as the block side; mark_busy() writes/clears it.
- keep legacy device-API fallback with minimal `qbool_untrusted_busy`: absent key = free, anything else = busy, no fancy parsing, since as for now never wrote a false literal anyway (we remove the key instead).